### PR TITLE
Fix layout in case of ListComponentHorizontalAlignmentRight

### DIFF
--- a/Component5-Demo/Component/ListComponent.m
+++ b/Component5-Demo/Component/ListComponent.m
@@ -154,7 +154,7 @@
 
                     case ListComponentHorizontalAlignmentLeft:break;
                     case ListComponentHorizontalAlignmentCenter: origin.x += ceilf(dxTotal/2); break;
-                    case ListComponentHorizontalAlignmentRight: origin.x += ceilf(dyTotal); break;
+                    case ListComponentHorizontalAlignmentRight: origin.x += ceilf(dxTotal); break;
                 }
 
                 const CGFloat dy = nodeSize.height - childNodeSize.height;


### PR DESCRIPTION
In case of right-aligned horizontal list the origin should be offset by the remaining horizontal, not vertical difference.